### PR TITLE
Add options for path-to-regexp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 language: node_js
 node_js:
 - node
+deploy:
+  provider: npm
+  email: christopher.andrejewski@gmail.com
+  api_key:
+    secure: Sf96ih6vQw36Tf0WgJn67Q1POwM73XuFCjodrWC13Xp/m8+b23F77DnnI64bRR6JdFbig/0sZjUwwE+OPyAb/ktppZrllIWQXMbOynGtmztMLDqXjPljjqPTfhNA5fw7BHWaFNsREzaqQPLv9/z0iyt52aPvhUcYJSYppV84Bye7nLGJRAgx/qzBSGNO/9JkLXR9HGCvTln9FI6afB2R97SXaQfJh3i0ivKVVKuvUcOKHZedVaBgtRF6e74JqP0gvW2dfWqJqTylDRdn3racy/AUuwkwJ8nlRjTGuA9OykgdcBiZB0Z09acGrH8tixavBzb1PWkKeak+Bdmgc9eSXqdc/VgTsF52bOh1FkeCkWy/ZLTF4dyIaphZvduN9rkD2+MOkG3xPY058c0OEKid4AzQQCq7A9+RDmf2kjW9zZytY5NmM9lnFUZ2IqIP7p4e6dbD++Ouet18DpdtkpC56W4+OJnAkKs9QGDmWzs8LToiKDK2GTvAOp4hcchppOb3ddvvh8PfGztDFn0lLGN2wAhvKDN/2mf58aJF112bDOx7JeU53DUUXQJzBYZDHhGUKWH6HpqUp9iUejnGVxAkDNOJZn58uE4qkRwXGsOPQTjtafP7pg1gADrGOC7Wx7Rz58BHjSJHAkPTNIxSe8V+XFHuYS1nBk/T36i+E888vmQ=
+  on:
+    tags: true
+    repo: andrejewski/tagged-routes

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ console.log(getURLForRoute(exemplarRoute))
 
 ## Documentation
 
-### `createRoutes(routeTable, catchAllRouteKind: string)`
-Accepts a `routeTable` object with route kinds (types of Route) as keys and valid [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) paths as values along with a catch-all route kind `catchAllRouteKind`.
+### `createRoutes(routeTable, catchAllRouteKind: string, options?: object)`
+Accepts a `routeTable` object with route kinds (types of Route) as keys and valid [`path-to-regexp`](https://github.com/pillarjs/path-to-regexp) paths as values along with a catch-all route kind `catchAllRouteKind`. The `options` are passed to `path-to-regexp` and `options.encode` is passed to `path-to-regexp.compile` URL builders to override the `encodeURIComponent` default.
 
 Returns an object containing the below `Route` union and functions.
 

--- a/test/index.js
+++ b/test/index.js
@@ -140,3 +140,19 @@ test('createRoutes().getURLForRoute should throw if missing routePath for catch-
     getURLForRoute(Route.NotFound({}))
   }, /route requires a/)
 })
+
+test('createRoutes().getURLForRoute should use the encode option if provided', t => {
+  const { Route, getURLForRoute } = createRoutes(
+    { Test: '/:foo/:bar/:baz' },
+    'NotFound',
+    {
+      encode: (value, token) => token.name
+    }
+  )
+  t.is(
+    getURLForRoute(
+      Route.Test({ routeParams: { foo: 'a', bar: 'b', baz: 'c' } })
+    ),
+    '/foo/bar/baz'
+  )
+})


### PR DESCRIPTION
People, like me, need to override the default encoding done by `path-to-regexp` in some cases. This adds that options proxy so we can do:

```js
const { Route, getURLForRoute } = createRoutes(
  { Test: '/:foo/:bar/:baz' },
  'NotFound',
  {
    encode: (value, token) => mySpecialEncoding(value)
  }
)
```
We can also pass any of the other [`path-to-regexp` options](https://github.com/pillarjs/path-to-regexp#usage).